### PR TITLE
Default to first available COM port

### DIFF
--- a/NogasmChart/MainWindow.xaml.cs
+++ b/NogasmChart/MainWindow.xaml.cs
@@ -57,7 +57,7 @@ namespace NogasmChart
 
             MenuFileSave.IsEnabled = false;
 
-            ComPort.SelectedItem = SerialPort.GetPortNames();
+            ComPort.SelectedItem = SerialPort.GetPortNames()[0];
 
             // ToDo: Make this selectable
             _analyser = new NogasmMotorDirectAnalyser();


### PR DESCRIPTION
I believe the intent of this line is to default to an available COM port, but as written I don't think it functions.

Adding the index at least selects the first COM list found to be available.

This also serves to fill the dropdown with a possible option. When empty (as it would be upon opening previously) I found the empty dropdown easy to overlook.